### PR TITLE
Use hidden node to stop placement of blocks in top half of travelnet

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -18,6 +18,8 @@ travelnet.doors_enabled            = true;
 -- starts an abm which re-adds travelnet stations to networks in case the savefile got lost
 travelnet.abm_enabled              = false;
 
+travelnet.block_existing_travelnets = minetest.settings:get_bool("travelnet.block_existing_travelnets", false)
+
 -- change these if you want other receipes for travelnet or elevator
 travelnet.travelnet_recipe = {
                 {"default:glass", "default:steel_ingot", "default:glass", },

--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,3 @@
 mesecons?
+mesecons_mvps?
 intllib?

--- a/elevator.lua
+++ b/elevator.lua
@@ -162,7 +162,6 @@ minetest.register_node("travelnet:elevator", {
     on_place = function(itemstack, placer, pointed_thing)
        local pos  = pointed_thing.above;
        local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z});
-	   local def = minetest.registered_nodes[node.name]
        -- leftover elevator_top nodes can be removed by placing a new elevator underneath
        local def = minetest.registered_nodes[node.name]
        if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then

--- a/elevator.lua
+++ b/elevator.lua
@@ -195,3 +195,7 @@ minetest.register_alias("travelnet:elevator_top", "air")
 	})
 --end
 
+if minetest.global_exists("mesecon") and mesecon.register_mvps_stopper then
+    mesecon.register_mvps_stopper("travelnet:elevator")
+end
+

--- a/elevator.lua
+++ b/elevator.lua
@@ -135,9 +135,9 @@ minetest.register_node("travelnet:elevator", {
 --                            "field[0.3,7.6;6,0.7;owner_name;(optional) owned by:;]"..
                             "button_exit[6.3,6.2;1.7,0.7;station_set;"..S("Store").."]" );
 
-       local p = {x=pos.x, y=pos.y+1, z=pos.z}
+		local top_pos = vector.add({x=0,y=1,z=0}, pos)
+		minetest.set_node(top_pos, {name="travelnet:hidden_top"})
        local p2 = minetest.dir_to_facedir(placer:get_look_dir())
-       minetest.add_node(p, {name="travelnet:elevator_top", paramtype2="facedir", param2=p2})
        travelnet.show_nearest_elevator( pos, placer:get_player_name(), p2 );
     end,
     
@@ -163,7 +163,8 @@ minetest.register_node("travelnet:elevator", {
        local pos  = pointed_thing.above;
        local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z});
        -- leftover elevator_top nodes can be removed by placing a new elevator underneath
-       if( node ~= nil and node.name ~= "air" and node.name ~= 'travelnet:elevator_top') then
+       local def = minetest.registered_nodes[node.name]
+       if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
           minetest.chat_send_player( placer:get_player_name(), S('Not enough vertical space to place the travelnet box!'))
           return;
        end

--- a/init.lua
+++ b/init.lua
@@ -94,6 +94,7 @@ travelnet = {};
 travelnet.targets = {};
 travelnet.path = minetest.get_modpath(minetest.get_current_modname())
 
+local hidden_block = "travelnet:hidden_top"
 
 -- Intllib
 local S = dofile(travelnet.path .. "/intllib.lua")
@@ -661,6 +662,14 @@ travelnet.on_receive_fields = function(pos, formname, fields, player)
    if( not( pos )) then
       return;
    end
+
+   if travelnet.block_existing_travelnets then
+      local top_pos = vector.add({x=0,y=1,z=0}, pos)
+      if minetest.get_node(top_pos).name ~= hidden_block then
+        minetest.set_node(top_pos, {name=hidden_block})
+      end
+    end
+
    local meta = minetest.get_meta(pos);
 
    local name = player:get_player_name();
@@ -843,6 +852,14 @@ travelnet.on_receive_fields = function(pos, formname, fields, player)
    local target_pos = travelnet.targets[ owner_name ][ station_network ][ fields.target ].pos;
    player:move_to( target_pos, false);
 
+
+   if travelnet.block_existing_travelnets then
+      local top_pos = vector.add({x=0,y=1,z=0}, target_pos)
+      if minetest.get_node(top_pos).name ~= hidden_block then
+        minetest.set_node(top_pos, {name=hidden_block})
+      end
+    end
+
    if( travelnet.travelnet_effect_enabled ) then 
       minetest.add_entity( {x=target_pos.x,y=target_pos.y+0.5,z=target_pos.z}, "travelnet:effect"); -- it self-destructs after 20 turns
    end
@@ -1012,10 +1029,10 @@ local hidden_def = {
 -- hidden_def.pointable = true
 -- hidden_def.drawtype = "glasslike"
 
-minetest.register_node("travelnet:hidden_top", hidden_def)
+minetest.register_node(hidden_block, hidden_def)
 
 if minetest.global_exists("mesecon") and mesecon.register_mvps_stopper then
-  mesecon.register_mvps_stopper("travelnet:hidden_top")
+  mesecon.register_mvps_stopper(hidden_block)
 end
 
 

--- a/init.lua
+++ b/init.lua
@@ -910,6 +910,8 @@ end
 
 travelnet.remove_box = function( pos, oldnode, oldmetadata, digger )
 
+   minetest.remove_node(vector.add({x=0,y=1,z=0}, pos))
+
    if( not( oldmetadata ) or oldmetadata=="nil" or not(oldmetadata.fields)) then
       minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
 		S("Could not find information about the station that is to be removed."));
@@ -988,8 +990,33 @@ travelnet.can_dig_old = function( pos, player, description )
    end
    return true;
 end
+local hidden_def = {
+  drawtype = "airlike",
+  paramtype = "light",
+  sunlight_propagates = true,
+  walkable = true,
+  pointable = false,
+  diggable = false,
+  builbable_to = false,
+  floodable = false,
+  drop="",
+  groups = {not_in_creative_inventory = 1},
+  on_blast = function () end,
+  collision_box = {
+    type = "fixed",
+    fixed = { 0,0,0,0,0,0 },
+  },
+}
+-- Make hidden node visible for debugging
+-- hidden_def.selection_box = {type="fixed",fixed={-0.3,-0.3,-0.3,0.3,0.3,0.3}}
+-- hidden_def.pointable = true
+-- hidden_def.drawtype = "glasslike"
 
+minetest.register_node("travelnet:hidden_top", hidden_def)
 
+if minetest.global_exists("mesecon") and mesecon.register_mvps_stopper then
+  mesecon.register_mvps_stopper("travelnet:hidden_top")
+end
 
 
 

--- a/travelnet.lua
+++ b/travelnet.lua
@@ -48,11 +48,13 @@ minetest.register_node("travelnet:travelnet", {
     light_source = 10,
 
     after_place_node  = function(pos, placer, itemstack)
-	local meta = minetest.get_meta(pos);
-	travelnet.reset_formspec( meta );
-        meta:set_string("owner",          placer:get_player_name() );
+		local meta = minetest.get_meta(pos);
+		travelnet.reset_formspec( meta );
+		meta:set_string("owner", placer:get_player_name() );
+		local top_pos = vector.add({x=0,y=1,z=0}, pos)
+		minetest.set_node(top_pos, {name="travelnet:hidden_top"})
     end,
-    
+
     on_receive_fields = travelnet.on_receive_fields,
     on_punch          = function(pos, node, puncher)
                              travelnet.update_formspec(pos, puncher:get_player_name(), nil)
@@ -74,10 +76,9 @@ minetest.register_node("travelnet:travelnet", {
     on_place = function(itemstack, placer, pointed_thing)
 
        local pos = pointed_thing.above;
-       local def = minetest.registered_nodes[
-             minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z}).name]
-       if not def or not def.buildable_to then
-
+       local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
+       local def = minetest.registered_nodes[node.name]
+       if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
           minetest.chat_send_player( placer:get_player_name(), S('Not enough vertical space to place the travelnet box!'))
           return;
        end
@@ -91,3 +92,7 @@ minetest.register_craft({
         output = "travelnet:travelnet",
         recipe = travelnet.travelnet_recipe,
 })
+
+if minetest.global_exists("mesecon") and mesecon.register_mvps_stopper then
+    mesecon.register_mvps_stopper("travelnet:travelnet")
+end


### PR DESCRIPTION
Fixes #55 

Duplicates https://github.com/Sokomine/travelnet/pull/66

Fixes https://github.com/BlockySurvival/issue-tracker/issues/204

Create a new hidden node, place it in the top half of the travelnet on creation, and remove it on deletion